### PR TITLE
Use cite instead of site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I'll keep updating this list as I learn more myself and feel free to contribute 
 * Could you explain the concept of microservices?
 * How do you go about learning something new?
 * How do you stay up to date with technology and programming? (Interviewer wants to be comfortable that your skillset will continue to stay current in regards to the role. Do answer honestly including sources like blogs, forums, books or courses.)
-* Can you site different types of testing.
+* Can you cite different types of testing.
 * What is the next thing you'd like to learn?
 * What have you built that you are most proud of? (Interviewer is looking to hear about your passion for programming and give you a chance to talk about specific technologies or methodologies you've used recently)
 * Can you explain what it means when a framework uses a `convention over configuration` approach?
@@ -38,7 +38,7 @@ I'll keep updating this list as I learn more myself and feel free to contribute 
 * Can you explain how you organise your CSS for responsiveness?
 * [What is tree shaking?](treeShaking.md)
 * What is hoisting?
-* Can you site at least one way to improve a website for accessibility?
+* Can you cite at least one way to improve a website for accessibility?
 * Can you explain event delegation in JavaScript?
 * Can you explain how the event loop works?
 * What is the difference between == and === in JavaScript?


### PR DESCRIPTION
I don't know what the word "site" does mean in other countries but what i do know its much better to use "cite" over "site". Example, this question on the [Frontend Section](https://github.com/charliegerard/mock-interview-questions/blob/master/README.md#art-front-end) "Can you site at least one way to improve a website for accessibility?". 

According to this [website](https://writingexplained.org/cite-vs-site-vs-sight-difference):

> Cite is a verb, meaning to quote or refer to (something), to summon to bring in front of a court, or to issue a notice of violation.

and

> Site is a noun, meaning a place or location whether physical (a building, a mall) or electronic (a website). 